### PR TITLE
Seed + change num rollouts for Mujoco/LunarLander

### DIFF
--- a/MujocoBenchmarks/src/mujocobenchmarks/functions.py
+++ b/MujocoBenchmarks/src/mujocobenchmarks/functions.py
@@ -43,12 +43,12 @@ class ObjectFactory(Generic[T]):
 
 
 class MujucoPolicyFunc:
-    ANT_ENV: ClassVar[Tuple[str, float, float, int]] = ('Ant-v2', -1.0, 1.0, 1)
+    ANT_ENV: ClassVar[Tuple[str, float, float, int]] = ('Ant-v2', -1.0, 1.0, 50)
     SWIMMER_ENV: ClassVar[Tuple[str, float, float, int]] = ('Swimmer-v2', -1.0, 1.0, 5)
-    HALF_CHEETAH_ENV: ClassVar[Tuple[str, float, float, int]] = ('HalfCheetah-v2', -1.0, 1.0, 5)
+    HALF_CHEETAH_ENV: ClassVar[Tuple[str, float, float, int]] = ('HalfCheetah-v2', -1.0, 1.0, 25)
     HOPPER_ENV: ClassVar[Tuple[str, float, float, int]] = ('Hopper-v2', -1.4, 1.4, 5)
-    WALKER_2D_ENV: ClassVar[Tuple[str, float, float, int]] = ('Walker2d-v2', -1.8, 0.9, 5)
-    HUMANOID_ENV: ClassVar[Tuple[str, float, float, int]] = ('Humanoid-v2', -1.0, 1.0, 5)
+    WALKER_2D_ENV: ClassVar[Tuple[str, float, float, int]] = ('Walker2d-v2', -1.8, 0.9, 10)
+    HUMANOID_ENV: ClassVar[Tuple[str, float, float, int]] = ('Humanoid-v2', -1.0, 1.0, 10)
 
     ENV_CP = {
         ANT_ENV[0]: 10.0,
@@ -96,8 +96,8 @@ class MujucoPolicyFunc:
             rewards = []
             observations = []
             actions = []
-            for _ in range(self._num_rollouts):
-                obs = self._env.reset()
+            for j in range(self._num_rollouts):
+                obs = self._env.reset(seed=j)
                 done = False
                 total_reward = 0.
                 steps = 0

--- a/MujocoBenchmarks/src/mujocobenchmarks/main.py
+++ b/MujocoBenchmarks/src/mujocobenchmarks/main.py
@@ -68,8 +68,10 @@ class MujocoServiceServicer(DualStackGRCPService):
     def __init__(
             self,
             port: int = 50057,
-            listen_hosts=None
+            listen_hosts=None,
+            lunarlander_rollouts: int = 50,
     ):
+        self._lunarlander_rollouts = lunarlander_rollouts
         super().__init__(port=port, n_cores=1, listen_hosts=listen_hosts)
 
     def evaluate_point(
@@ -90,19 +92,22 @@ class MujocoServiceServicer(DualStackGRCPService):
         elif request.benchmark.name == 'lunarlander':
             env = gym.make("LunarLander-v2")
             try:
-                total_reward = 0
-                s = env.reset()
-                while True:
-                    a = heuristic_controller(s, x.squeeze())
-                    s, r, terminated, _ = env.step(a)
-                    total_reward += r
+                rewards = []
+                for i in range(self._lunarlander_rollouts):
+                    total_reward = 0.
+                    s = env.reset(seed=i)
+                    while True:
+                        a = heuristic_controller(s, x.squeeze())
+                        s, r, terminated, _ = env.step(a)
+                        total_reward += r
 
-                    if terminated:
-                        break
+                        if terminated:
+                            break
+                    rewards.append(total_reward)
             finally:
                 env.close()
             result = EvaluationResult(
-                value=-total_reward
+                value=-float(np.mean(rewards))
             )
         else:
             raise ValueError("Invalid benchmark name")
@@ -119,11 +124,22 @@ def serve():
         help='The port number to start the server on. Default is 50057. '
              'Can also be set via the BENCHER_MUJOCO_PORT environment variable.',
     )
+    parser.add_argument(
+        '--lunarlander-rollouts',
+        type=int,
+        default=int(os.environ.get('BENCHER_LUNARLANDER_ROLLOUTS', 50)),
+        help='Number of fixed terrain seeds averaged per Lunar Lander evaluation. '
+             'Can also be set via the BENCHER_LUNARLANDER_ROLLOUTS environment variable.',
+    )
     add_listen_argument(parser, env_var=LISTEN_HOST_ENV_VAR)
     args = parser.parse_args()
 
     logging.basicConfig()
-    mujoco = MujocoServiceServicer(port=args.port, listen_hosts=resolve_listen_entries(args.listen_hosts, env_var=LISTEN_HOST_ENV_VAR))
+    mujoco = MujocoServiceServicer(
+        port=args.port,
+        listen_hosts=resolve_listen_entries(args.listen_hosts, env_var=LISTEN_HOST_ENV_VAR),
+        lunarlander_rollouts=args.lunarlander_rollouts
+    )
     mujoco.serve()
 
 


### PR DESCRIPTION
This PR addresses two different (but related) problems:
1. seed the MuJoCo and Lunar Lander rollouts
2. decide how many rollouts are needed for each benchmark

#### 1. Seed the MuJoCo and Lunar Lander rollouts

`env.reset()` was called without a seed, so every evaluation drew a fresh initial state and the same policy scored differently on each call. I spotted this problem while running a BO algorithm on Lunar Lander: one of the seeds of this BO run was suspiciously low compared to the other seeds, which led me to realize that specific seed actually started with a way worse Lunar Lander set-up (due to the randomly generated terrain, initial positions, and velocities).

#### 2. How many rollouts are needed

Once seeded, the benchmark is deterministic but not unique: a different fixed seed set gives a different objective. Ideally, the number of rollouts `K` should be big enough such that it represents the average Mujoco/LunarLander set-up accurately. To get a sense of which `K` would be needed for each benchmark, I ran a small test with the help of Claude. Here's the Claude summary of what was tried: "I measured whether the choice of seed-set changes the ordering of points an optimizer visits. For 25 points per benchmark (spread across a Vanilla BO run), each was evaluated on 100 rollout seeds; `f` was then computed on two disjoint seed blocks of size `K` and the two rankings compared by Spearman." I'm sure there are other ways to do this, and this metric is probably biased in one way or another. Nevertheless, if it's just to get a rough estimate on how to set these numbers, I think this metric actually does a decent job.

| benchmark | K=1 | K=5 | K=10 | K=25 |
|---|---|---|---|---|
| hopper | **0.996** | 0.992 | 0.996 | 0.996 |
| swimmer | 0.943 | **0.968** | 0.985 | 0.995 |
| walker | 0.572 | 0.924 | **0.951** | 0.982 |
| humanoid | 0.736 | **0.947** | 0.942 | 0.982 |
| lunarlander | 0.741 | 0.812 | 0.932 | **0.975** |
| halfcheetah | 0.753 | 0.882 | 0.891 | **0.977** |
| ant | 0.180 | 0.436 | 0.422 | 0.575 |

For each benchmark, I've bolded the smallest `K` that is around .95 or higher. Then, I took a look at how this would affect the timings, and chose `K` such that the average evaluation would still be around 1s-2s. The main exception here is Ant, which would need even more than `K=25`, but is already kinda slow... I also decided to go for `K=50` on Lunar Lander, cause that's what they use in the original TuRBO paper.

| benchmark | K | s/rollout | s/eval at that K |
|---|---|---|---|
| walker | 10 | 0.029 | 0.30 |
| swimmer | 5 | 0.120 | 0.60 |
| hopper | 5 | 0.190 | 0.95 |
| humanoid | 10 | 0.098 | 0.98 |
| halfcheetah | 25 | 0.062 | 1.56 |
| lunarlander | 50 | 0.049 | 2.44 |
| ant | 50 | 0.429 | 21.5 |

The timings above are from an actual Vanilla BO run. This is important, because randomly sampling points will not give a realistic timing: they'll probably find a walker or humanoid that falls instantly to the floor, leading to very short rollouts.

In the end, my choices in the above table are pretty subjective. I'm happy for you to challenge these opinions and push for slightly different numbers. The main point of this PR is not to argue these numbers are the absolute best ones, but rather to start a discussion on how to set them in a way that makes sense (e.g. maximize how well they would represent the true average, while keeping the evaluation time under 1s-3s). I'm also not too sure what to do with Ant... keen to have your opinion on that one as well.

Thanks for all the time you put into `bencher`!